### PR TITLE
Fix reverse position calculation in Sequence.py

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,14 @@
 Release Notes
 ================================================================================
 
+Version 0.7.9dev
+-------------------------------------------------------------------------------
+
+MaskPrimers:
+
++ Fixed a bug in MaskPrimers align involving the reverse primer position offset 
+calculation.
+
 Version 0.7.8: January 28, 2026
 -------------------------------------------------------------------------------
 

--- a/presto/Sequence.py
+++ b/presto/Sequence.py
@@ -903,7 +903,7 @@ def localAlignment(seq_record, primers, primers_regex=None, max_error=default_as
             align.end = align_coord[0][-1]
         else:
             # Count position from tail and end gaps
-            rev_pos = rec_len - align_coord[0][-1]
+            rev_pos = rec_len - max_len if rec_len > max_len else 0
             align.start = rev_pos + align_coord[0][0]
             align.end = rev_pos + align_coord[0][-1]
 

--- a/presto/Version.py
+++ b/presto/Version.py
@@ -5,5 +5,5 @@ Version and authorship information
 __author__    = 'Jason Anthony Vander Heiden'
 __copyright__ = 'Copyright 2026 Kleinstein Lab, Yale University. All rights reserved.'
 __license__   = 'GNU Affero General Public License 3 (AGPL-3)'
-__version__   = '0.7.8'
+__version__   = '0.7.9dev'
 __date__      = '2026.01.28'


### PR DESCRIPTION
The bugfix corrects an error in the calculation of the location of the best alignment of the reverse primer.
Whereas the original code calculated the _offset_ by subtracting the alignment-end coordinate, the _offset_ **should** be either (a) the last position in the sequence record considered (given the user-chosen `--maxlen` value) of (b) zero, if the considered length covers the entire sequence record (in which case the start of the matched position comes directly from the unmodified alignment coordinates). The actual start and end of the site are then calculated by adding the _offset_ to the alignment coordinates.

This situation only comes up for reverse primers, where the regex failed due to imperfect matching.